### PR TITLE
Update util.lua

### DIFF
--- a/package/gluon-hoodselector/luasrc/usr/lib/lua/hoodselector/util.lua
+++ b/package/gluon-hoodselector/luasrc/usr/lib/lua/hoodselector/util.lua
@@ -140,7 +140,7 @@ function M.restart_services()
 		"gluon-respondd",
 	}
 
-	for proc in ipairs(proc_tbl) do
+	for i, proc in ipairs(proc_tbl) do
 		if unistd.access("/etc/init.d/"..proc, "x") == 0 then
 			print(proc.." restarting ...")
 			os.execute("/etc/init.d/"..proc.." restart")


### PR DESCRIPTION
processes are really restarted now. new (old) problem: nodes will not forget their former ipv6-addresses. watchdog could here with that.